### PR TITLE
[git] git add -p

### DIFF
--- a/ambiente/git.md
+++ b/ambiente/git.md
@@ -29,7 +29,10 @@ Crear una rama o branch nueva
 
 Agregar y Quitar archivos (Equivalente git add, git rm juntos)
   $ git add -u
-  
+
+Añadir porciones de cambios dentro de cada archivo al stage de cambios
+  $ git add -p
+
 Quitar archivos
   $ git rm
 
@@ -43,7 +46,7 @@ Deshacer cambios del pull mas reciente
 
 Retrocedemos al último commit y perdemos todos los cambios hechos.
   $ git reset --hard HEAD~1
-  
+
 Retrocedemos a el último commit y no perdemos los cambiosn hechos; apareceran pendientes de hace commit
   $ git reset --soft HEAD~1
 


### PR DESCRIPTION
añado `git add -p` a los comandos útiles, porque ayuda a realizar una auto-revisión a detalle de cada cambio en cada archivo. para que no haya sorpresas que añadiste (debug, etc).

páginando cada cambio, puedes añadir, obviar, olvidar o pasar de un cambio hecho. todo lo aceptado (y) añade al stage para el commit próximo. 

[este artículo](https://dev.to/sharpshark28/self-code-review-with-git-add-patch) es el mejor que explica porque te ayuda `git add -p` y no solo hacer `git add *`